### PR TITLE
fix: restore generated SDK conformance

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -1,6 +1,7 @@
 name: Functional tests
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -17,7 +18,7 @@ concurrency:
 
 jobs:
   functional-tests:
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'workflow_dispatch'
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:

--- a/e2e/live/test_responses.py
+++ b/e2e/live/test_responses.py
@@ -7,7 +7,7 @@ def test_responses() -> None:
     with create_client() as client:
         response = client.responses.create(
             input="Reply with only the word pong.",
-            max_output_tokens=16,
+            max_output_tokens=128,
             preset="pro-search",
         )
 

--- a/e2e/live/test_search.py
+++ b/e2e/live/test_search.py
@@ -11,4 +11,4 @@ def test_search() -> None:
     assert search.results
     assert search.results[0].title
     assert search.results[0].url
-    assert search.results[0].snippet
+    assert isinstance(search.results[0].snippet, str)

--- a/e2e/live/test_streaming_responses.py
+++ b/e2e/live/test_streaming_responses.py
@@ -7,7 +7,7 @@ def test_streaming_responses() -> None:
     with create_client() as client:
         stream = client.responses.create(
             input="Reply with only the word pong.",
-            max_output_tokens=16,
+            max_output_tokens=128,
             preset="pro-search",
             stream=True,
         )

--- a/src/perplexity/_client.py
+++ b/src/perplexity/_client.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import Any, Mapping
 from typing_extensions import Self, override
 
 import httpx
@@ -33,20 +33,15 @@ from ._base_client import (
     SyncAPIClient,
     AsyncAPIClient,
 )
+from .resources._client import (
+    SyncClientResources,
+    AsyncClientResources,
+    SyncClientWithRawResponse,
+    AsyncClientWithRawResponse,
+    SyncClientWithStreamingResponse,
+    AsyncClientWithStreamingResponse,
+)
 from ._generated_transport import SyncTransportAdapter, AsyncTransportAdapter
-
-if TYPE_CHECKING:
-    from .resources import chat, async_, search, browser, responses, embeddings, contextualized_embeddings
-    from .resources.search import SearchResource, AsyncSearchResource
-    from .resources.chat.chat import ChatResource, AsyncChatResource
-    from .resources.embeddings import EmbeddingsResource, AsyncEmbeddingsResource
-    from .resources.async_.async_ import AsyncResource, AsyncAsyncResource
-    from .resources.browser.browser import BrowserResource, AsyncBrowserResource
-    from .resources.responses.responses import ResponsesResource, AsyncResponsesResource
-    from .resources.contextualized_embeddings import (
-        ContextualizedEmbeddingsResource,
-        AsyncContextualizedEmbeddingsResource,
-    )
 
 __all__ = [
     "Timeout",
@@ -60,7 +55,7 @@ __all__ = [
 ]
 
 
-class Perplexity(SyncAPIClient):
+class Perplexity(SyncClientResources, SyncAPIClient):
     # client options
     api_key: str
 
@@ -125,48 +120,7 @@ class Perplexity(SyncAPIClient):
         )
 
         self._default_stream_cls = Stream
-
-    @cached_property
-    def chat(self) -> ChatResource:
-        from .resources.chat import ChatResource
-
-        return ChatResource(SyncTransportAdapter(self))
-
-    @cached_property
-    def search(self) -> SearchResource:
-        from .resources.search import SearchResource
-
-        return SearchResource(SyncTransportAdapter(self))
-
-    @cached_property
-    def responses(self) -> ResponsesResource:
-        from .resources.responses import ResponsesResource
-
-        return ResponsesResource(SyncTransportAdapter(self))
-
-    @cached_property
-    def embeddings(self) -> EmbeddingsResource:
-        from .resources.embeddings import EmbeddingsResource
-
-        return EmbeddingsResource(SyncTransportAdapter(self))
-
-    @cached_property
-    def contextualized_embeddings(self) -> ContextualizedEmbeddingsResource:
-        from .resources.contextualized_embeddings import ContextualizedEmbeddingsResource
-
-        return ContextualizedEmbeddingsResource(SyncTransportAdapter(self))
-
-    @cached_property
-    def browser(self) -> BrowserResource:
-        from .resources.browser import BrowserResource
-
-        return BrowserResource(SyncTransportAdapter(self))
-
-    @cached_property
-    def async_(self) -> AsyncResource:
-        from .resources.async_ import AsyncResource
-
-        return AsyncResource(SyncTransportAdapter(self))
+        self._sdk_transport = SyncTransportAdapter(self)
 
     @cached_property
     def with_raw_response(self) -> PerplexityWithRawResponse:
@@ -283,7 +237,7 @@ class Perplexity(SyncAPIClient):
         return APIStatusError(err_msg, response=response, body=body)
 
 
-class AsyncPerplexity(AsyncAPIClient):
+class AsyncPerplexity(AsyncClientResources, AsyncAPIClient):
     # client options
     api_key: str
 
@@ -348,48 +302,7 @@ class AsyncPerplexity(AsyncAPIClient):
         )
 
         self._default_stream_cls = AsyncStream
-
-    @cached_property
-    def chat(self) -> AsyncChatResource:
-        from .resources.chat import AsyncChatResource
-
-        return AsyncChatResource(AsyncTransportAdapter(self))
-
-    @cached_property
-    def search(self) -> AsyncSearchResource:
-        from .resources.search import AsyncSearchResource
-
-        return AsyncSearchResource(AsyncTransportAdapter(self))
-
-    @cached_property
-    def responses(self) -> AsyncResponsesResource:
-        from .resources.responses import AsyncResponsesResource
-
-        return AsyncResponsesResource(AsyncTransportAdapter(self))
-
-    @cached_property
-    def embeddings(self) -> AsyncEmbeddingsResource:
-        from .resources.embeddings import AsyncEmbeddingsResource
-
-        return AsyncEmbeddingsResource(AsyncTransportAdapter(self))
-
-    @cached_property
-    def contextualized_embeddings(self) -> AsyncContextualizedEmbeddingsResource:
-        from .resources.contextualized_embeddings import AsyncContextualizedEmbeddingsResource
-
-        return AsyncContextualizedEmbeddingsResource(AsyncTransportAdapter(self))
-
-    @cached_property
-    def browser(self) -> AsyncBrowserResource:
-        from .resources.browser import AsyncBrowserResource
-
-        return AsyncBrowserResource(AsyncTransportAdapter(self))
-
-    @cached_property
-    def async_(self) -> AsyncAsyncResource:
-        from .resources.async_ import AsyncAsyncResource
-
-        return AsyncAsyncResource(AsyncTransportAdapter(self))
+        self._sdk_transport = AsyncTransportAdapter(self)
 
     @cached_property
     def with_raw_response(self) -> AsyncPerplexityWithRawResponse:
@@ -506,206 +419,24 @@ class AsyncPerplexity(AsyncAPIClient):
         return APIStatusError(err_msg, response=response, body=body)
 
 
-class PerplexityWithRawResponse:
-    _client: Perplexity
-
+class PerplexityWithRawResponse(SyncClientWithRawResponse):
     def __init__(self, client: Perplexity) -> None:
-        self._client = client
-
-    @cached_property
-    def chat(self) -> chat.ChatResourceWithRawResponse:
-        from .resources.chat import ChatResourceWithRawResponse
-
-        return ChatResourceWithRawResponse(self._client.chat)
-
-    @cached_property
-    def search(self) -> search.SearchResourceWithRawResponse:
-        from .resources.search import SearchResourceWithRawResponse
-
-        return SearchResourceWithRawResponse(self._client.search)
-
-    @cached_property
-    def responses(self) -> responses.ResponsesResourceWithRawResponse:
-        from .resources.responses import ResponsesResourceWithRawResponse
-
-        return ResponsesResourceWithRawResponse(self._client.responses)
-
-    @cached_property
-    def embeddings(self) -> embeddings.EmbeddingsResourceWithRawResponse:
-        from .resources.embeddings import EmbeddingsResourceWithRawResponse
-
-        return EmbeddingsResourceWithRawResponse(self._client.embeddings)
-
-    @cached_property
-    def contextualized_embeddings(self) -> contextualized_embeddings.ContextualizedEmbeddingsResourceWithRawResponse:
-        from .resources.contextualized_embeddings import ContextualizedEmbeddingsResourceWithRawResponse
-
-        return ContextualizedEmbeddingsResourceWithRawResponse(self._client.contextualized_embeddings)
-
-    @cached_property
-    def browser(self) -> browser.BrowserResourceWithRawResponse:
-        from .resources.browser import BrowserResourceWithRawResponse
-
-        return BrowserResourceWithRawResponse(self._client.browser)
-
-    @cached_property
-    def async_(self) -> async_.AsyncResourceWithRawResponse:
-        from .resources.async_ import AsyncResourceWithRawResponse
-
-        return AsyncResourceWithRawResponse(self._client.async_)
+        super().__init__(client)
 
 
-class AsyncPerplexityWithRawResponse:
-    _client: AsyncPerplexity
-
+class AsyncPerplexityWithRawResponse(AsyncClientWithRawResponse):
     def __init__(self, client: AsyncPerplexity) -> None:
-        self._client = client
-
-    @cached_property
-    def chat(self) -> chat.AsyncChatResourceWithRawResponse:
-        from .resources.chat import AsyncChatResourceWithRawResponse
-
-        return AsyncChatResourceWithRawResponse(self._client.chat)
-
-    @cached_property
-    def search(self) -> search.AsyncSearchResourceWithRawResponse:
-        from .resources.search import AsyncSearchResourceWithRawResponse
-
-        return AsyncSearchResourceWithRawResponse(self._client.search)
-
-    @cached_property
-    def responses(self) -> responses.AsyncResponsesResourceWithRawResponse:
-        from .resources.responses import AsyncResponsesResourceWithRawResponse
-
-        return AsyncResponsesResourceWithRawResponse(self._client.responses)
-
-    @cached_property
-    def embeddings(self) -> embeddings.AsyncEmbeddingsResourceWithRawResponse:
-        from .resources.embeddings import AsyncEmbeddingsResourceWithRawResponse
-
-        return AsyncEmbeddingsResourceWithRawResponse(self._client.embeddings)
-
-    @cached_property
-    def contextualized_embeddings(
-        self,
-    ) -> contextualized_embeddings.AsyncContextualizedEmbeddingsResourceWithRawResponse:
-        from .resources.contextualized_embeddings import AsyncContextualizedEmbeddingsResourceWithRawResponse
-
-        return AsyncContextualizedEmbeddingsResourceWithRawResponse(self._client.contextualized_embeddings)
-
-    @cached_property
-    def browser(self) -> browser.AsyncBrowserResourceWithRawResponse:
-        from .resources.browser import AsyncBrowserResourceWithRawResponse
-
-        return AsyncBrowserResourceWithRawResponse(self._client.browser)
-
-    @cached_property
-    def async_(self) -> async_.AsyncAsyncResourceWithRawResponse:
-        from .resources.async_ import AsyncAsyncResourceWithRawResponse
-
-        return AsyncAsyncResourceWithRawResponse(self._client.async_)
+        super().__init__(client)
 
 
-class PerplexityWithStreamedResponse:
-    _client: Perplexity
-
+class PerplexityWithStreamedResponse(SyncClientWithStreamingResponse):
     def __init__(self, client: Perplexity) -> None:
-        self._client = client
-
-    @cached_property
-    def chat(self) -> chat.ChatResourceWithStreamingResponse:
-        from .resources.chat import ChatResourceWithStreamingResponse
-
-        return ChatResourceWithStreamingResponse(self._client.chat)
-
-    @cached_property
-    def search(self) -> search.SearchResourceWithStreamingResponse:
-        from .resources.search import SearchResourceWithStreamingResponse
-
-        return SearchResourceWithStreamingResponse(self._client.search)
-
-    @cached_property
-    def responses(self) -> responses.ResponsesResourceWithStreamingResponse:
-        from .resources.responses import ResponsesResourceWithStreamingResponse
-
-        return ResponsesResourceWithStreamingResponse(self._client.responses)
-
-    @cached_property
-    def embeddings(self) -> embeddings.EmbeddingsResourceWithStreamingResponse:
-        from .resources.embeddings import EmbeddingsResourceWithStreamingResponse
-
-        return EmbeddingsResourceWithStreamingResponse(self._client.embeddings)
-
-    @cached_property
-    def contextualized_embeddings(
-        self,
-    ) -> contextualized_embeddings.ContextualizedEmbeddingsResourceWithStreamingResponse:
-        from .resources.contextualized_embeddings import ContextualizedEmbeddingsResourceWithStreamingResponse
-
-        return ContextualizedEmbeddingsResourceWithStreamingResponse(self._client.contextualized_embeddings)
-
-    @cached_property
-    def browser(self) -> browser.BrowserResourceWithStreamingResponse:
-        from .resources.browser import BrowserResourceWithStreamingResponse
-
-        return BrowserResourceWithStreamingResponse(self._client.browser)
-
-    @cached_property
-    def async_(self) -> async_.AsyncResourceWithStreamingResponse:
-        from .resources.async_ import AsyncResourceWithStreamingResponse
-
-        return AsyncResourceWithStreamingResponse(self._client.async_)
+        super().__init__(client)
 
 
-class AsyncPerplexityWithStreamedResponse:
-    _client: AsyncPerplexity
-
+class AsyncPerplexityWithStreamedResponse(AsyncClientWithStreamingResponse):
     def __init__(self, client: AsyncPerplexity) -> None:
-        self._client = client
-
-    @cached_property
-    def chat(self) -> chat.AsyncChatResourceWithStreamingResponse:
-        from .resources.chat import AsyncChatResourceWithStreamingResponse
-
-        return AsyncChatResourceWithStreamingResponse(self._client.chat)
-
-    @cached_property
-    def search(self) -> search.AsyncSearchResourceWithStreamingResponse:
-        from .resources.search import AsyncSearchResourceWithStreamingResponse
-
-        return AsyncSearchResourceWithStreamingResponse(self._client.search)
-
-    @cached_property
-    def responses(self) -> responses.AsyncResponsesResourceWithStreamingResponse:
-        from .resources.responses import AsyncResponsesResourceWithStreamingResponse
-
-        return AsyncResponsesResourceWithStreamingResponse(self._client.responses)
-
-    @cached_property
-    def embeddings(self) -> embeddings.AsyncEmbeddingsResourceWithStreamingResponse:
-        from .resources.embeddings import AsyncEmbeddingsResourceWithStreamingResponse
-
-        return AsyncEmbeddingsResourceWithStreamingResponse(self._client.embeddings)
-
-    @cached_property
-    def contextualized_embeddings(
-        self,
-    ) -> contextualized_embeddings.AsyncContextualizedEmbeddingsResourceWithStreamingResponse:
-        from .resources.contextualized_embeddings import AsyncContextualizedEmbeddingsResourceWithStreamingResponse
-
-        return AsyncContextualizedEmbeddingsResourceWithStreamingResponse(self._client.contextualized_embeddings)
-
-    @cached_property
-    def browser(self) -> browser.AsyncBrowserResourceWithStreamingResponse:
-        from .resources.browser import AsyncBrowserResourceWithStreamingResponse
-
-        return AsyncBrowserResourceWithStreamingResponse(self._client.browser)
-
-    @cached_property
-    def async_(self) -> async_.AsyncAsyncResourceWithStreamingResponse:
-        from .resources.async_ import AsyncAsyncResourceWithStreamingResponse
-
-        return AsyncAsyncResourceWithStreamingResponse(self._client.async_)
+        super().__init__(client)
 
 
 Client = Perplexity

--- a/src/perplexity/_models.py
+++ b/src/perplexity/_models.py
@@ -649,6 +649,9 @@ def construct_type(*, value: object, type_: object, metadata: Optional[List[Any]
             if issubclass(type_, BaseModel):
                 return type_.construct(**value)  # type: ignore[arg-type]
 
+            if issubclass(type_, GeneratedBaseModel):
+                return cast(Any, BaseModel.construct).__func__(type_, **value)
+
             return cast(Any, type_).model_construct(**value)
 
     if origin == list:

--- a/src/perplexity/resources/_client.py
+++ b/src/perplexity/resources/_client.py
@@ -1,0 +1,272 @@
+from functools import cached_property
+
+from perplexity.generated.runtime import AsyncTransport, SyncTransport
+from .async_ import (
+    AsyncResource,
+    AsyncAsyncResource,
+    AsyncResourceWithRawResponse,
+    AsyncAsyncResourceWithRawResponse,
+    AsyncResourceWithStreamingResponse,
+    AsyncAsyncResourceWithStreamingResponse,
+)
+from .browser import (
+    BrowserResource,
+    AsyncBrowserResource,
+    BrowserResourceWithRawResponse,
+    AsyncBrowserResourceWithRawResponse,
+    BrowserResourceWithStreamingResponse,
+    AsyncBrowserResourceWithStreamingResponse,
+)
+from .chat import (
+    ChatResource,
+    AsyncChatResource,
+    ChatResourceWithRawResponse,
+    AsyncChatResourceWithRawResponse,
+    ChatResourceWithStreamingResponse,
+    AsyncChatResourceWithStreamingResponse,
+)
+from .contextualized_embeddings import (
+    ContextualizedEmbeddingsResource,
+    AsyncContextualizedEmbeddingsResource,
+    ContextualizedEmbeddingsResourceWithRawResponse,
+    AsyncContextualizedEmbeddingsResourceWithRawResponse,
+    ContextualizedEmbeddingsResourceWithStreamingResponse,
+    AsyncContextualizedEmbeddingsResourceWithStreamingResponse,
+)
+from .embeddings import (
+    EmbeddingsResource,
+    AsyncEmbeddingsResource,
+    EmbeddingsResourceWithRawResponse,
+    AsyncEmbeddingsResourceWithRawResponse,
+    EmbeddingsResourceWithStreamingResponse,
+    AsyncEmbeddingsResourceWithStreamingResponse,
+)
+from .responses import (
+    ResponsesResource,
+    AsyncResponsesResource,
+    ResponsesResourceWithRawResponse,
+    AsyncResponsesResourceWithRawResponse,
+    ResponsesResourceWithStreamingResponse,
+    AsyncResponsesResourceWithStreamingResponse,
+)
+from .search import (
+    SearchResource,
+    AsyncSearchResource,
+    SearchResourceWithRawResponse,
+    AsyncSearchResourceWithRawResponse,
+    SearchResourceWithStreamingResponse,
+    AsyncSearchResourceWithStreamingResponse,
+)
+
+
+class SyncClientResources:
+    _sdk_transport: SyncTransport
+
+    @cached_property
+    def async_(self) -> AsyncResource:
+        return AsyncResource(self._sdk_transport)
+
+    @cached_property
+    def browser(self) -> BrowserResource:
+        return BrowserResource(self._sdk_transport)
+
+    @cached_property
+    def chat(self) -> ChatResource:
+        return ChatResource(self._sdk_transport)
+
+    @cached_property
+    def contextualized_embeddings(self) -> ContextualizedEmbeddingsResource:
+        return ContextualizedEmbeddingsResource(self._sdk_transport)
+
+    @cached_property
+    def embeddings(self) -> EmbeddingsResource:
+        return EmbeddingsResource(self._sdk_transport)
+
+    @cached_property
+    def responses(self) -> ResponsesResource:
+        return ResponsesResource(self._sdk_transport)
+
+    @cached_property
+    def search(self) -> SearchResource:
+        return SearchResource(self._sdk_transport)
+
+
+class AsyncClientResources:
+    _sdk_transport: AsyncTransport
+
+    @cached_property
+    def async_(self) -> AsyncAsyncResource:
+        return AsyncAsyncResource(self._sdk_transport)
+
+    @cached_property
+    def browser(self) -> AsyncBrowserResource:
+        return AsyncBrowserResource(self._sdk_transport)
+
+    @cached_property
+    def chat(self) -> AsyncChatResource:
+        return AsyncChatResource(self._sdk_transport)
+
+    @cached_property
+    def contextualized_embeddings(self) -> AsyncContextualizedEmbeddingsResource:
+        return AsyncContextualizedEmbeddingsResource(self._sdk_transport)
+
+    @cached_property
+    def embeddings(self) -> AsyncEmbeddingsResource:
+        return AsyncEmbeddingsResource(self._sdk_transport)
+
+    @cached_property
+    def responses(self) -> AsyncResponsesResource:
+        return AsyncResponsesResource(self._sdk_transport)
+
+    @cached_property
+    def search(self) -> AsyncSearchResource:
+        return AsyncSearchResource(self._sdk_transport)
+
+
+class SyncClientWithRawResponse:
+    def __init__(self, client: SyncClientResources) -> None:
+        self._client = client
+
+    @cached_property
+    def async_(self) -> AsyncResourceWithRawResponse:
+        return AsyncResourceWithRawResponse(self._client.async_)
+
+    @cached_property
+    def browser(self) -> BrowserResourceWithRawResponse:
+        return BrowserResourceWithRawResponse(self._client.browser)
+
+    @cached_property
+    def chat(self) -> ChatResourceWithRawResponse:
+        return ChatResourceWithRawResponse(self._client.chat)
+
+    @cached_property
+    def contextualized_embeddings(
+        self,
+    ) -> ContextualizedEmbeddingsResourceWithRawResponse:
+        return ContextualizedEmbeddingsResourceWithRawResponse(
+            self._client.contextualized_embeddings
+        )
+
+    @cached_property
+    def embeddings(self) -> EmbeddingsResourceWithRawResponse:
+        return EmbeddingsResourceWithRawResponse(self._client.embeddings)
+
+    @cached_property
+    def responses(self) -> ResponsesResourceWithRawResponse:
+        return ResponsesResourceWithRawResponse(self._client.responses)
+
+    @cached_property
+    def search(self) -> SearchResourceWithRawResponse:
+        return SearchResourceWithRawResponse(self._client.search)
+
+
+class AsyncClientWithRawResponse:
+    def __init__(self, client: AsyncClientResources) -> None:
+        self._client = client
+
+    @cached_property
+    def async_(self) -> AsyncAsyncResourceWithRawResponse:
+        return AsyncAsyncResourceWithRawResponse(self._client.async_)
+
+    @cached_property
+    def browser(self) -> AsyncBrowserResourceWithRawResponse:
+        return AsyncBrowserResourceWithRawResponse(self._client.browser)
+
+    @cached_property
+    def chat(self) -> AsyncChatResourceWithRawResponse:
+        return AsyncChatResourceWithRawResponse(self._client.chat)
+
+    @cached_property
+    def contextualized_embeddings(
+        self,
+    ) -> AsyncContextualizedEmbeddingsResourceWithRawResponse:
+        return AsyncContextualizedEmbeddingsResourceWithRawResponse(
+            self._client.contextualized_embeddings
+        )
+
+    @cached_property
+    def embeddings(self) -> AsyncEmbeddingsResourceWithRawResponse:
+        return AsyncEmbeddingsResourceWithRawResponse(self._client.embeddings)
+
+    @cached_property
+    def responses(self) -> AsyncResponsesResourceWithRawResponse:
+        return AsyncResponsesResourceWithRawResponse(self._client.responses)
+
+    @cached_property
+    def search(self) -> AsyncSearchResourceWithRawResponse:
+        return AsyncSearchResourceWithRawResponse(self._client.search)
+
+
+class SyncClientWithStreamingResponse:
+    def __init__(self, client: SyncClientResources) -> None:
+        self._client = client
+
+    @cached_property
+    def async_(self) -> AsyncResourceWithStreamingResponse:
+        return AsyncResourceWithStreamingResponse(self._client.async_)
+
+    @cached_property
+    def browser(self) -> BrowserResourceWithStreamingResponse:
+        return BrowserResourceWithStreamingResponse(self._client.browser)
+
+    @cached_property
+    def chat(self) -> ChatResourceWithStreamingResponse:
+        return ChatResourceWithStreamingResponse(self._client.chat)
+
+    @cached_property
+    def contextualized_embeddings(
+        self,
+    ) -> ContextualizedEmbeddingsResourceWithStreamingResponse:
+        return ContextualizedEmbeddingsResourceWithStreamingResponse(
+            self._client.contextualized_embeddings
+        )
+
+    @cached_property
+    def embeddings(self) -> EmbeddingsResourceWithStreamingResponse:
+        return EmbeddingsResourceWithStreamingResponse(self._client.embeddings)
+
+    @cached_property
+    def responses(self) -> ResponsesResourceWithStreamingResponse:
+        return ResponsesResourceWithStreamingResponse(self._client.responses)
+
+    @cached_property
+    def search(self) -> SearchResourceWithStreamingResponse:
+        return SearchResourceWithStreamingResponse(self._client.search)
+
+
+class AsyncClientWithStreamingResponse:
+    def __init__(self, client: AsyncClientResources) -> None:
+        self._client = client
+
+    @cached_property
+    def async_(self) -> AsyncAsyncResourceWithStreamingResponse:
+        return AsyncAsyncResourceWithStreamingResponse(self._client.async_)
+
+    @cached_property
+    def browser(self) -> AsyncBrowserResourceWithStreamingResponse:
+        return AsyncBrowserResourceWithStreamingResponse(self._client.browser)
+
+    @cached_property
+    def chat(self) -> AsyncChatResourceWithStreamingResponse:
+        return AsyncChatResourceWithStreamingResponse(self._client.chat)
+
+    @cached_property
+    def contextualized_embeddings(
+        self,
+    ) -> AsyncContextualizedEmbeddingsResourceWithStreamingResponse:
+        return AsyncContextualizedEmbeddingsResourceWithStreamingResponse(
+            self._client.contextualized_embeddings
+        )
+
+    @cached_property
+    def embeddings(self) -> AsyncEmbeddingsResourceWithStreamingResponse:
+        return AsyncEmbeddingsResourceWithStreamingResponse(self._client.embeddings)
+
+    @cached_property
+    def responses(self) -> AsyncResponsesResourceWithStreamingResponse:
+        return AsyncResponsesResourceWithStreamingResponse(self._client.responses)
+
+    @cached_property
+    def search(self) -> AsyncSearchResourceWithStreamingResponse:
+        return AsyncSearchResourceWithStreamingResponse(self._client.search)
+

--- a/tests/test_generated_api_integration.py
+++ b/tests/test_generated_api_integration.py
@@ -6,7 +6,10 @@ import httpx
 
 from perplexity import Perplexity
 from perplexity.types import SearchCreateResponse
-from perplexity.generated.api import SearchCreateResponse as GeneratedSearchCreateResponse
+from perplexity.generated.api import (
+    ApiSearchPageOutput,
+    SearchCreateResponse as GeneratedSearchCreateResponse,
+)
 
 
 def test_client_uses_generated_api_and_model() -> None:
@@ -16,7 +19,16 @@ def test_client_uses_generated_api_and_model() -> None:
         requests.append(request)
         return httpx.Response(
             200,
-            json={"id": "search-1", "results": []},
+            json={
+                "id": "search-1",
+                "results": [
+                    {
+                        "snippet": "An answer engine.",
+                        "title": "Perplexity",
+                        "url": "https://www.perplexity.ai",
+                    }
+                ],
+            },
             request=request,
         )
 
@@ -29,5 +41,7 @@ def test_client_uses_generated_api_and_model() -> None:
 
     assert SearchCreateResponse is GeneratedSearchCreateResponse
     assert isinstance(response, GeneratedSearchCreateResponse)
+    assert isinstance(response.results[0], ApiSearchPageOutput)
+    assert response.results[0].title == "Perplexity"
     assert requests[0].url == "https://example.test/search"
     assert json.loads(requests[0].content) == {"query": "perplexity"}

--- a/tests/test_resource_compatibility.py
+++ b/tests/test_resource_compatibility.py
@@ -4,7 +4,7 @@ import importlib
 
 import pytest
 
-from perplexity import Perplexity
+from perplexity import Perplexity, AsyncPerplexity
 from perplexity.generated import api as generated
 
 RESOURCE_MODULES = [
@@ -72,3 +72,22 @@ def test_client_resource_graph_uses_generated_resources() -> None:
         assert isinstance(client.responses.files, generated.ResponsesFilesResource)
         assert isinstance(client.browser.sessions, generated.BrowserSessionsResource)
         assert isinstance(client.async_.chat.completions, generated.AsyncChatCompletionsResource)
+        assert isinstance(client.with_raw_response.chat, generated.ChatResourceWithRawResponse)
+        assert isinstance(
+            client.with_streaming_response.responses,
+            generated.ResponsesResourceWithStreamingResponse,
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_client_resource_graph_uses_generated_resources() -> None:
+    async with AsyncPerplexity(api_key="test", base_url="https://example.test") as client:
+        assert isinstance(client.chat, generated.AsyncClientChatResource)
+        assert isinstance(
+            client.with_raw_response.chat,
+            generated.AsyncClientChatResourceWithRawResponse,
+        )
+        assert isinstance(
+            client.with_streaming_response.responses,
+            generated.AsyncClientResponsesResourceWithStreamingResponse,
+        )


### PR DESCRIPTION
## Why

Main functional run `30423812445` exposed two response-construction issues. Python client also repeated 42 generated-shaped resource accessors across sync, async, raw-response, and streaming-response clients.

## What

- recursively construct nested generated response models without strict validation
- accept valid empty Search snippets
- raise Responses live-test output budget to 128 tokens
- run functional tests on same-repo pull requests
- consume generated root client resource mixins
- preserve public client and wrapper class names

Client mixins are generated by [ppl-ai/agi#179690](https://github.com/ppl-ai/agi/pull/179690) from shared `sdk_resources`.

## Test

- `bazel test //...` — 27/27 passed
- mypy, Ruff, Gazelle passed
- PR functional run before client refactor — 8/8 passed: https://github.com/perplexityai/perplexity-py/actions/runs/30424378378
