### PR TITLE
ci: automate releases with Release Please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,28 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    name: Create or update release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Run Release Please
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## What

- run Release Please on every push to `main` and by manual dispatch
- use existing Python release config and manifest
- authenticate with repository `RELEASE_TOKEN` so release PRs and releases trigger CI and PyPI publishing

## Why

Python releases were still managed by Stainless. This brings release automation in-repo and matches `perplexity-node`.

## Validation

- `bazel test //...` (27/27)
- Lefthook: Gazelle, mypy, Ruff check/format
- Commitlint

## Rollout

Removed stale `autorelease: pending` from closed Stainless release PR #68. Disable Stainless release management after merge to avoid duplicate release PRs.
