### PR TITLE
docs: document development and release workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,53 +1,63 @@
-## Development
+# Contributing
 
-Install [Bazelisk](https://github.com/bazelbuild/bazelisk), install development
-tools, then enable Git hooks:
+## Setup
+
+Install Node 26 and [Bazelisk](https://github.com/bazelbuild/bazelisk), then
+enable the repository's pinned `pnpm`:
 
 ```sh
+corepack enable pnpm
 pnpm install --frozen-lockfile
 pnpm lefthook install
 ```
 
-Bazel provisions Python and all Python dependencies. No virtual environment is
+Bazel provisions Python and Python dependencies. No virtual environment is
 required.
 
-## Dependencies and BUILD files
+## Make changes
 
-Declare dependencies in `pyproject.toml`. Configure UV in `uv.toml`, then
-update the lock:
+Handwritten client, transport, and helper code lives under `src/perplexity/`.
+Do not edit `src/perplexity/generated/` or `src/perplexity/resources/`; the SDK
+code is produced by a private SDK codegen pipeline.
 
-```sh
-bazel run //:uv_lock.update
-```
+Tests live under `tests/`. Live API tests live under `e2e/live/` and must remain
+small and deterministic.
 
-`gazelle_py` owns test BUILD targets:
+For a dependency change:
 
-```sh
-bazel run //:gazelle
-```
+1. Update `pyproject.toml`.
+2. Keep the `py_wheel.requires` metadata in `BUILD.bazel` aligned.
+3. Update the lock and BUILD files:
 
-Commit generated `BUILD.bazel` and `uv.lock` changes.
+   ```sh
+   bazel run //:uv_lock.update
+   bazel run //:gazelle
+   ```
 
-## Tests
+Commit resulting `uv.lock` and `BUILD.bazel` changes.
 
-Run all tests, including source type checking and wheel construction:
+Use [Conventional Commits](https://www.conventionalcommits.org/), such as
+`fix: handle empty responses` or `feat: add a resource`. Release Please uses
+these commits to choose the next version and build the changelog.
+
+## Test
+
+Run the same main test suite as CI:
 
 ```sh
 bazel test //...
 ```
 
-Run one test:
+Run one target while iterating:
 
 ```sh
-bazel test //tests:test_client
+bazel test //tests:test_client_test
 ```
 
-## Linting and formatting
-
-Lefthook runs Gazelle, mypy, and Ruff:
+Validate formatting, lint, types, and generated BUILD files:
 
 ```sh
-pnpm lefthook run pre-commit --all-files
+pnpm lefthook run pre-commit --all-files --force --fail-on-changes
 ```
 
 Apply Ruff fixes:
@@ -57,32 +67,34 @@ bazel run //:ruff -- check --fix .
 bazel run //:ruff -- format .
 ```
 
-## Building
+Live tests call the production API and require a token. Run only the relevant
+shard:
 
-Build the wheel:
+```sh
+PPLX_API_TOKEN=... bazel test //e2e/live:search --test_env=PPLX_API_TOKEN
+```
+
+Build the publishable wheel:
 
 ```sh
 bazel build //:wheel
 ```
 
-The wheel is written beneath `bazel-bin`.
+The output is under `bazel-bin/`.
 
-## Generated code
+## Release
 
-Most SDK code is generated. Manual changes survive regeneration but may
-conflict with later generator output. The generator does not modify
-`src/perplexity/lib/` or `examples/`.
+Do not bump versions or publish from a development branch.
 
-## Examples
+1. Merge normal PRs into `main`.
+2. Release Please creates or updates a `release: <version>` PR from Conventional
+   Commits.
+3. Review and merge that PR. It updates the changelog and version files, then
+   creates the `v<version>` tag and GitHub release.
+4. The published GitHub release triggers `Publish PyPI`, which runs
+   `bazel run //:wheel.publish`.
 
-Run examples with any Python environment containing the built package:
-
-```sh
-python examples/<example>.py
-```
-
-## Publishing
-
-Release Please creates release PRs and GitHub releases. A published release
-triggers the `Publish PyPI` workflow, which builds and publishes `//:wheel`.
-The workflow requires `PERPLEXITY_PYPI_TOKEN` or `PYPI_TOKEN`.
+Release automation requires `RELEASE_TOKEN`. PyPI publishing currently uses
+`PERPLEXITY_PYPI_TOKEN`, with `PYPI_TOKEN` as a fallback. For a failed upload,
+rerun `Publish PyPI` against the existing release tag; do not create a new
+version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Install Node 26 and [Bazelisk](https://github.com/bazelbuild/bazelisk), then
 enable the repository's pinned `pnpm`:
 
 ```sh
+npm install --global corepack@latest
 corepack enable pnpm
 pnpm install --frozen-lockfile
 pnpm lefthook install
@@ -25,7 +26,8 @@ small and deterministic.
 
 For a dependency change:
 
-1. Update `pyproject.toml`.
+1. Update dependencies in `pyproject.toml`. Change `uv.toml` only for UV
+   resolver or index configuration.
 2. Keep the `py_wheel.requires` metadata in `BUILD.bazel` aligned.
 3. Update the lock and BUILD files:
 


### PR DESCRIPTION
## What

- document setup, dependency, test, and wheel workflows
- mark private-codegen output as generated
- document Conventional Commits and Release Please to PyPI

## Why

Contributors need one current path from local change through release.

## Test

- `bazel test //...` (27/27)
- `bazel run //:gazelle -- -mode=diff`
- pre-commit checks
