### PR TITLE
ci: publish PyPI releases with OIDC

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -12,6 +12,9 @@ jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,8 +25,13 @@ jobs:
           bazelisk-cache: true
           repository-cache: true
 
+      - name: Build wheel
+        run: |
+          bazel build //:wheel
+          mkdir -p dist
+          cp "$(bazel cquery --output=files //:wheel)" dist/
+
       - name: Publish to PyPI
-        run: bazel run //:wheel.publish -- --non-interactive
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PERPLEXITY_PYPI_TOKEN || secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          packages-dir: dist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,10 +93,10 @@ Do not bump versions or publish from a development branch.
    Commits.
 3. Review and merge that PR. It updates the changelog and version files, then
    creates the `v<version>` tag and GitHub release.
-4. The published GitHub release triggers `Publish PyPI`, which runs
-   `bazel run //:wheel.publish`.
+4. The published GitHub release triggers `Publish PyPI`, which builds `//:wheel`
+   and uploads it through PyPI Trusted Publishing.
 
-Release automation requires `RELEASE_TOKEN`. PyPI publishing currently uses
-`PERPLEXITY_PYPI_TOKEN`, with `PYPI_TOKEN` as a fallback. For a failed upload,
-rerun `Publish PyPI` against the existing release tag; do not create a new
-version.
+Release automation requires `RELEASE_TOKEN`. PyPI trusts `publish-pypi.yml`
+through GitHub Actions OIDC; no PyPI token is stored in GitHub. For a failed
+upload, rerun `Publish PyPI` against the existing release tag; do not create a
+new version.


### PR DESCRIPTION
## What

- build the Bazel wheel before publishing
- publish through PyPI Trusted Publishing with GitHub Actions OIDC
- remove long-lived PyPI token use
- update contributor release docs

## Why

PyPI now trusts `publish-pypi.yml`, so releases can use short-lived credentials instead of repository secrets.

## Test

- `bazel test //:wheel_test //e2e:wheel_conformance_test`
- reproduced workflow staging with `bazel cquery --output=files //:wheel`
- verified staged wheel archive
- Oxfmt and `git diff --check`
