### PR TITLE
fix: publish stable GitHub releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,8 +5,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
-  "versioning": "prerelease",
-  "prerelease": true,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "pull-request-header": "Automated Release PR",


### PR DESCRIPTION
## Summary

- remove prerelease mode from Release Please
- keep existing pre-1.0 bump rules

## Why

Stable versions were published correctly, but GitHub releases were marked as prereleases.

## Validation

- `bazel test //...`
- `pnpm lefthook run pre-commit --all-files --force --fail-on-changes`
