### PR TITLE
docs: clarify PyPI installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ The REST API documentation can be found on [docs.perplexity.ai](https://docs.per
 
 ## Installation
 
+Install the package from PyPI:
+
 ```sh
-# install from PyPI
 pip install perplexityai
 ```
 


### PR DESCRIPTION
## Summary
- move the PyPI installation guidance outside the shell code block
- keep the command directly copyable

## Testing
- not run (documentation-only change)