### PR TITLE
docs: use canonical Server-Sent Events terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ asyncio.run(main())
 
 ## Streaming responses
 
-We provide support for streaming responses using Server Side Events (SSE).
+We provide support for streaming responses using Server-Sent Events (SSE).
 
 ```python
 from perplexity import Perplexity


### PR DESCRIPTION
## Summary
- replace "Server Side Events" with the canonical term "Server-Sent Events" in the streaming documentation

## Testing
- not run (documentation-only change)