### PR TITLE
Docs: use standard Server-Sent Events terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ asyncio.run(main())
 
 ## Streaming responses
 
-We provide support for streaming responses using Server Side Events (SSE).
+We provide support for streaming responses using Server-Sent Events (SSE).
 
 ```python
 from perplexity import Perplexity


### PR DESCRIPTION
## Summary
- replace “Server Side Events” with the standard term “Server-Sent Events”

## Testing
- Not run (documentation-only change).