### PR TITLE
docs: use standard Server-Sent Events terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ asyncio.run(main())
 
 ## Streaming responses
 
-We provide support for streaming responses using Server Side Events (SSE).
+We provide support for streaming responses using Server-Sent Events (SSE).
 
 ```python
 from perplexity import Perplexity


### PR DESCRIPTION
## Summary
- Correct the streaming protocol name in the README to the standard “Server-Sent Events” terminology.

Only `README.md` was changed.