### PR TITLE
docs: clarify Python requirement for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The REST API documentation can be found on [docs.perplexity.ai](https://docs.per
 ## Installation
 
 ```sh
+# requires Python 3.9 or later
 # install from PyPI
 pip install perplexityai
 ```


### PR DESCRIPTION
## Summary
- state the Python 3.9+ requirement in the installation snippet

## Testing
- Not run (documentation-only change)