### PR TITLE
docs: use correct Server-Sent Events term

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ asyncio.run(main())
 
 ## Streaming responses
 
-We provide support for streaming responses using Server Side Events (SSE).
+We provide support for streaming responses using Server-Sent Events (SSE).
 
 ```python
 from perplexity import Perplexity


### PR DESCRIPTION
## Summary
- Correct the expansion of SSE in the streaming responses documentation.

## Testing
- Not run (documentation-only change).