### PR TITLE
docs: document ConflictError for HTTP 409

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Error codes are as follows:
 | 401         | `AuthenticationError`      |
 | 403         | `PermissionDeniedError`    |
 | 404         | `NotFoundError`            |
+| 409         | `ConflictError`            |
 | 422         | `UnprocessableEntityError` |
 | 429         | `RateLimitError`           |
 | >=500       | `InternalServerError`      |


### PR DESCRIPTION
## Summary
- add the missing HTTP 409 / `ConflictError` entry to the README error-code table

## Validation
- `git diff --check`