### PR TITLE
fix: allow reasoning.effort "none" for third-party models (#45)

### DIFF
--- a/src/perplexity/generated/api.py
+++ b/src/perplexity/generated/api.py
@@ -1310,11 +1310,11 @@ class PeopleSearchToolOutput(BaseModel):
 
 
 class ReasoningConfigInput(BaseModel):
-    effort: Optional[Literal["minimal", "low", "medium", "high", "xhigh"]] = None
+    effort: Optional[Literal["minimal", "low", "medium", "high", "xhigh", "none"]] = None
 
 
 class ReasoningConfigOutput(BaseModel):
-    effort: Optional[Literal["minimal", "low", "medium", "high", "xhigh"]] = None
+    effort: Optional[Literal["minimal", "low", "medium", "high", "xhigh", "none"]] = None
 
 
 class ReasoningInputItemInput(BaseModel):

--- a/src/perplexity/types/response_create_params.py
+++ b/src/perplexity/types/response_create_params.py
@@ -114,7 +114,7 @@ class ResponseCreateParamsBase(TypedDict, total=False):
 
 
 class Reasoning(TypedDict, total=False):
-    effort: Literal["minimal", "low", "medium", "high", "xhigh"]
+    effort: Literal["minimal", "low", "medium", "high", "xhigh", "none"]
     """How much effort the model should spend on reasoning"""
 
 


### PR DESCRIPTION
Fixes #45

## Summary
Adds `"none"` to the `reasoning.effort` Literal so the Responses API can be used with third-party models (e.g. `openai/gpt-5-mini`) that support `reasoning_effort: "none"`.

## Root cause
`Reasoning.effort` in `src/perplexity/types/response_create_params.py` and `ReasoningConfigInput`/`ReasoningConfigOutput` in `src/perplexity/generated/api.py` only allowed `minimal | low | medium | high | xhigh`. The server already accepts `none` for proxied third-party models, but the SDK rejected it client-side:

```
ValidationError: Input should be 'minimal', 'low', 'medium', 'high' or 'xhigh' [type=literal_error, input_value='none']
```

When the value did slip through, the API error surfaced as `400 - effort must be one of: low medium high`.

## Fix
- `src/perplexity/types/response_create_params.py`: `Literal["minimal","low","medium","high","xhigh"]` becomes `Literal["minimal","low","medium","high","xhigh","none"]`
- `src/perplexity/generated/api.py`: same change in `ReasoningConfigInput` and `ReasoningConfigOutput` (2 sites)

No behavior change for existing values. `none` matches OpenAI's `reasoning_effort: "none"` for the same underlying models.

## Verification
- Reproduced locally: `ReasoningConfigInput(effort="none")` raised `ValidationError` before and succeeds after. Same for `ReasoningConfigOutput`. Existing values (`minimal`/`low`/`medium`/`high`/`xhigh`/`None`) still pass, invalid values are still rejected.
- `PYTHONPATH=src python -m pytest tests/test_models.py tests/test_required_args.py tests/test_response.py tests/test_transform.py`: 146 passed.
